### PR TITLE
Use the current openSUSE upstream in the action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
     - uses: actions/checkout@v3
       with:
-        repository: kalikiana/backlogger
+        repository: openSUSE/backlogger
         path: backlogger
     - uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Although this is still magically being redirected it's misleading.