### PR TITLE
Support influxdb as an alternate output mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argparse
 requests
 urllib3
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 argparse
 requests
+statistics
 urllib3
 pyyaml
 pytest

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -10,9 +10,9 @@ import backlogger
 
 class TestComments(unittest.TestCase):
     def test_comments(self):
-        data = {"url": "https://example.com/issues", "web": "https://example.com/wiki"}
+        data = {"url": "https://example.com/issues", "web": "https://example.com/wiki",
+                "reminder-comment-on-issues": True}
         backlogger.data = data
-        sys.argv[1:] = ["--reminder-comment-on-issues"]
         backlogger.json_rest = MagicMock(return_value=None)
         backlogger.list_issues(
             {"query": "query_id=123&c%5B%5D=updated_on"},
@@ -41,9 +41,10 @@ class TestComments(unittest.TestCase):
 
 
     def test_no_repeat(self):
-        data = {"url": "https://example.com/issues", "web": "https://example.com/wiki", "api": "https://example.com/issues.json"}
+        data = {"url": "https://example.com/issues", "web": "https://example.com/wiki",
+                "api": "https://example.com/issues.json",
+                "reminder-comment-on-issues": True}
         backlogger.data = data
-        sys.argv[1:] = ["--reminder-comment-on-issues"]
         rest = {
             "issue": {
                 "id": 1000,

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, call
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import backlogger
+
+
+class TestOutput(unittest.TestCase):
+    def test_influxdb(self):
+        data = {"api": "https://example.com/issues.json", "team": "Awesome Team", "output": "influxdb",
+                "queries": [{"title": "Workable Backlog", "query": "query_id=123"}]}
+        backlogger.data = data
+        backlogger.json_rest = MagicMock(return_value={"issues":[], "total_count":2})
+        self.assertEqual(backlogger.render_influxdb(data),
+                         ['slo,team="Awesome Team",title="Workable Backlog" count=2'])

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -10,9 +10,66 @@ import backlogger
 
 class TestOutput(unittest.TestCase):
     def test_influxdb(self):
-        data = {"api": "https://example.com/issues.json", "team": "Awesome Team", "output": "influxdb",
-                "queries": [{"title": "Workable Backlog", "query": "query_id=123"}]}
+        data = {
+            "api": "https://example.com/issues.json",
+            "web": "https://example.com/issues",
+            "team": "Awesome Team",
+            "output": "influxdb",
+            "queries": [{"title": "Workable Backlog", "query": "query_id=123"}],
+        }
         backlogger.data = data
-        backlogger.json_rest = MagicMock(return_value={"issues":[], "total_count":2})
-        self.assertEqual(backlogger.render_influxdb(data),
-                         ['slo,team="Awesome Team",title="Workable Backlog" count=2'])
+        backlogger.json_rest = MagicMock(
+            side_effect=[
+                {"issue_statuses": [{"name": "In Progress", "id": 2}]},
+                {
+                    "issues": [
+                        {
+                            "id": 1,
+                            "status": {"name": "In Progress"},
+                            "created_on": "2022-12-12T07:51:24Z",
+                            "updated_on": "2022-12-19T12:34:52Z",
+                        },
+                        {
+                            "id": 2,
+                            "status": {"name": "In Progress"},
+                            "created_on": "2022-12-06T21:32:03Z",
+                            "updated_on": "2022-12-09T13:19:29Z",
+                        },
+                        {
+                            "id": 3,
+                            "status": {"name": "Resolved"},
+                            "created_on": "2022-12-06T13:57:05Z",
+                            "updated_on": "2022-12-22T13:12:22Z",
+                        },
+                    ],
+                    "total_count": 3,
+                },
+                {
+                    "issue": {
+                        "journals": [
+                            {
+                                "details": [{"name": "status_id", "new_value": "2"}],
+                                "created_on": "2022-12-10T13:57:05Z",
+                            },
+                            {
+                                "details": [
+                                    {
+                                        "name": "status_id",
+                                        "old_value": "2",
+                                        "new_value": "3",
+                                    }
+                                ],
+                                "created_on": "2022-12-12T13:57:05Z",
+                            },
+                        ]
+                    }
+                },
+            ]
+        )
+        self.assertEqual(
+            backlogger.render_influxdb(data),
+            [
+                'slo,team="Awesome Team",status="In Progress",title="Workable Backlog" count=2',
+                'leadTime,team="Awesome Team",status="Resolved",title="Workable Backlog" count=1 leadTime=383.2547222222222 cycleTime=48.0',
+            ],
+        )


### PR DESCRIPTION
- Use argparse for cleaner handling of switches.
- Remove verbatim printing to stdout that would interfere.
- Output InfluxDB line protocol instead of markdown

See: https://progress.opensuse.org/issues/121582