### PR TITLE
Fix InfluxDB output mode and add CI for it

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,3 +15,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - run: pytest -vv
+      - name: Install Telegraf
+        run: sudo apt-get install -y telegraf
+      - name: Test InfluxDB output
+        run: telegraf --test --config tests/slo.conf

--- a/backlogger.py
+++ b/backlogger.py
@@ -177,7 +177,7 @@ def render_influxdb(data):
             count = len(result[status]["leadTime"])
             if status == "Resolved":
                 measure = "leadTime"
-                extra = " leadTime={leadTime} cycleTime={cycleTime}".format(
+                extra = ",leadTime={leadTime},cycleTime={cycleTime}".format(
                     leadTime=mean(result[status]["leadTime"]),
                     cycleTime=mean(result[status]["cycleTime"]),
                 )
@@ -187,9 +187,9 @@ def render_influxdb(data):
             output.append(
                 '{measure},team="{team}",status="{status}",title="{title}" count={count}{extra}'.format(
                     measure=measure,
-                    team=data["team"],
-                    status=status,
-                    title=conf["title"],
+                    team="\\ ".join(data["team"].split(" ")),
+                    status="\\ ".join(status.split(" ")),
+                    title="\\ ".join(conf["title"].split(" ")),
                     count=count,
                     extra=extra,
                 )

--- a/tests/slo.conf
+++ b/tests/slo.conf
@@ -1,0 +1,5 @@
+[[inputs.exec]]
+  commands = [ "env REDMINE_API_KEY=abcdefgah0123456789 ./backlogger.py --output=influxdb" ]
+  interval = "1h"
+  timeout = "10s"
+  data_format = "influx"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -69,7 +69,7 @@ class TestOutput(unittest.TestCase):
         self.assertEqual(
             backlogger.render_influxdb(data),
             [
-                'slo,team="Awesome Team",status="In Progress",title="Workable Backlog" count=2',
-                'leadTime,team="Awesome Team",status="Resolved",title="Workable Backlog" count=1 leadTime=383.2547222222222 cycleTime=48.0',
+                'slo,team="Awesome\\ Team",status="In\\ Progress",title="Workable\\ Backlog" count=2',
+                'leadTime,team="Awesome\\ Team",status="Resolved",title="Workable\\ Backlog" count=1,leadTime=383.2547222222222,cycleTime=48.0',
             ],
         )


### PR DESCRIPTION
- Escape spaces in tags using backslashes
- Add a simple Telegraf config that reproduces syntax errors

See: https://progress.opensuse.org/issues/121582