### PR TITLE
Add sum of cycleTime and leadTime to influxdb output

### DIFF
--- a/backlogger.py
+++ b/backlogger.py
@@ -166,7 +166,7 @@ def render_influxdb(data):
             status = issue["status"]["name"]
             if status not in status_names:
                 status_names.append(status)
-                result[status] = {"avg": 0, "leadTime": [], "cycleTime": []}
+                result[status] = {"leadTime": [], "cycleTime": []}
 
             start = datetime.strptime(issue["created_on"], "%Y-%m-%dT%H:%M:%SZ")
             end = datetime.strptime(issue["updated_on"], "%Y-%m-%dT%H:%M:%SZ")

--- a/backlogger.py
+++ b/backlogger.py
@@ -174,14 +174,15 @@ def render_influxdb(data):
             if status == "Resolved":
                 result[status]["cycleTime"].append(cycle_time(issue, status_ids))
         for status in status_names:
-            count = len(result[status]["leadTime"])
+            times = result[status]
+            count = len(times["leadTime"])
             if status == "Resolved":
                 measure = "leadTime"
                 extra = ",leadTime={leadTime},cycleTime={cycleTime},leadTimeSum={leadTimeSum},cycleTimeSum={cycleTimeSum}".format(
-                    leadTime=mean(result[status]["leadTime"]) / 3600,
-                    cycleTime=mean(result[status]["cycleTime"]) / 3600,
-                    leadTimeSum=sum(result[status]["leadTime"]) / 3600,
-                    cycleTimeSum=sum(result[status]["cycleTime"]) / 3600,
+                    leadTime=mean(times["leadTime"]) / 3600,
+                    cycleTime=mean(times["cycleTime"]) / 3600,
+                    leadTimeSum=sum(times["leadTime"]) / 3600,
+                    cycleTimeSum=sum(times["cycleTime"]) / 3600,
                 )
             else:
                 measure = "slo"

--- a/backlogger.py
+++ b/backlogger.py
@@ -145,7 +145,7 @@ def cycle_time(issue, status_ids):
                     start = datetime.strptime(journal["created_on"], "%Y-%m-%dT%H:%M:%SZ")
                 elif detail["old_value"] == str(status_ids["In Progress"]):
                     end = datetime.strptime(journal["created_on"], "%Y-%m-%dT%H:%M:%SZ")
-                    cycle_time += (end - start).total_seconds() / 3600
+                    cycle_time += (end - start).total_seconds()
     return cycle_time
 
 
@@ -170,16 +170,18 @@ def render_influxdb(data):
 
             start = datetime.strptime(issue["created_on"], "%Y-%m-%dT%H:%M:%SZ")
             end = datetime.strptime(issue["updated_on"], "%Y-%m-%dT%H:%M:%SZ")
-            result[status]["leadTime"].append((end - start).total_seconds() / 3600)
+            result[status]["leadTime"].append((end - start).total_seconds())
             if status == "Resolved":
                 result[status]["cycleTime"].append(cycle_time(issue, status_ids))
         for status in status_names:
             count = len(result[status]["leadTime"])
             if status == "Resolved":
                 measure = "leadTime"
-                extra = ",leadTime={leadTime},cycleTime={cycleTime}".format(
-                    leadTime=mean(result[status]["leadTime"]),
-                    cycleTime=mean(result[status]["cycleTime"]),
+                extra = ",leadTime={leadTime},cycleTime={cycleTime},leadTimeSum={leadTimeSum},cycleTimeSum={cycleTimeSum}".format(
+                    leadTime=mean(result[status]["leadTime"]) / 3600,
+                    cycleTime=mean(result[status]["cycleTime"]) / 3600,
+                    leadTimeSum=sum(result[status]["leadTime"]) / 3600,
+                    cycleTimeSum=sum(result[status]["cycleTime"]) / 3600,
                 )
             else:
                 measure = "slo"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -41,8 +41,14 @@ class TestOutput(unittest.TestCase):
                             "created_on": "2022-12-06T13:57:05Z",
                             "updated_on": "2022-12-22T13:12:22Z",
                         },
+                        {
+                            "id": 4,
+                            "status": {"name": "Resolved"},
+                            "created_on": "2022-12-08T10:00:00Z",
+                            "updated_on": "2022-12-15T10:00:00Z",
+                        },
                     ],
-                    "total_count": 3,
+                    "total_count": 4,
                 },
                 {
                     "issue": {
@@ -64,12 +70,32 @@ class TestOutput(unittest.TestCase):
                         ]
                     }
                 },
+                {
+                    "issue": {
+                        "journals": [
+                            {
+                                "details": [{"name": "status_id", "new_value": "2"}],
+                                "created_on": "2022-12-10T10:00:00Z",
+                            },
+                            {
+                                "details": [
+                                    {
+                                        "name": "status_id",
+                                        "old_value": "2",
+                                        "new_value": "3",
+                                    }
+                                ],
+                                "created_on": "2022-12-12T10:00:00Z",
+                            },
+                        ]
+                    }
+                },
             ]
         )
         self.assertEqual(
             backlogger.render_influxdb(data),
             [
                 'slo,team="Awesome\\ Team",status="In\\ Progress",title="Workable\\ Backlog" count=2',
-                'leadTime,team="Awesome\\ Team",status="Resolved",title="Workable\\ Backlog" count=1,leadTime=383.2547222222222,cycleTime=48.0',
+                'leadTime,team="Awesome\\ Team",status="Resolved",title="Workable\\ Backlog" count=2,leadTime=275.6273611111111,cycleTime=48.0,leadTimeSum=551.2547222222222,cycleTimeSum=96.0',
             ],
         )


### PR DESCRIPTION
In order to calculate averages of arbitrary time frames in Grafana, we need the original count and sums.

Issue: https://progress.opensuse.org/issues/121582

I also moved the division by 3600 to the end. The later it is done, the less rounding errors can accumulate.