### PR TITLE
Increase issue limit to the maximum 100

### DIFF
--- a/backlogger.py
+++ b/backlogger.py
@@ -158,7 +158,7 @@ def render_influxdb(data):
         status_ids[status["name"]] = status["id"]
 
     for conf in data["queries"]:
-        root = json_rest("GET", data["api"] + "?" + conf["query"])
+        root = json_rest("GET", data["api"] + "?" + conf["query"] + "&limit=100")
         issue_count = list_issues(conf, root)
         status_names = []
         result = {}


### PR DESCRIPTION
Make sure we get as much issues as we can. The default redmine limit is 25, and the maximum limit one can set is 100.

If we want to make sure we get *all* issues we would have to add paging via 'offset'.

Issue: https://progress.opensuse.org/issues/121582