### PR TITLE
Add timestamp in nanoseconds for influxdb output

### DIFF
--- a/backlogger.py
+++ b/backlogger.py
@@ -144,6 +144,12 @@ def cycle_time(issue, status_ids):
     return cycle_time
 
 
+def _today_nanoseconds():
+    dt = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    epoch = datetime.utcfromtimestamp(0)
+    return int((dt-epoch).total_seconds()*1000000000)
+
+
 def render_influxdb(data):
     output = []
 
@@ -192,6 +198,8 @@ def render_influxdb(data):
                     extra=extra,
                 )
             )
+            if status == "Resolved":
+                output[-1] += " " + str(_today_nanoseconds())
     return output
 
 if __name__ == "__main__":

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -93,11 +93,12 @@ class TestOutput(unittest.TestCase):
                 },
             ]
         )
+        backlogger._today_nanoseconds = MagicMock(side_effect=[23])
         self.assertEqual(
             backlogger.render_influxdb(backlogger.data),
             [
                 'slo,team="Awesome\\ Team",status="In\\ Progress",title="Workable\\ Backlog" count=2',
-                'leadTime,team="Awesome\\ Team",status="Resolved",title="Workable\\ Backlog" count=2,leadTime=275.6273611111111,cycleTime=48.0,leadTimeSum=551.2547222222222,cycleTimeSum=96.0',
+                'leadTime,team="Awesome\\ Team",status="Resolved",title="Workable\\ Backlog" count=2,leadTime=275.6273611111111,cycleTime=48.0,leadTimeSum=551.2547222222222,cycleTimeSum=96.0 23',
             ],
         )
 


### PR DESCRIPTION
For the "Closed yesterday" query we can tell telegraf the exact timestamp for the data.
This way we can execute the telegraf query more often per day to ensure we get data, and also for the other queries there's no need to run this only once a day.

Ticket: https://progress.opensuse.org/issues/121582#note-57

Ideally one would mock `datetime.datetime.today` but I haven't found out how to do that with MagicMock