### PR TITLE
Enable usage of different exit code when queries not satisfied 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Additional arguments affecting the behavior of the script:
 
 `--reminder-comment-on-issues` can be added here to enable automatic reminder comments. This is **not** enabled by default because it's designed to be used in scheduled runs. Manual execution and previews of changed queries are not expected to have side-effects.
 
+`--exit-code` can be added to also emit return code 3 if any of the configured queries is not within its limit.
+
 ## folder
 
 The output folder for the generated HTML. By default this is `gh-pages`.

--- a/backlogger.py
+++ b/backlogger.py
@@ -17,7 +17,10 @@ import re
 # Icons used for PASS or FAIL in the md file
 result_icons = {"pass": "&#x1F49A;", "fail": "&#x1F534;"}
 reminder_text = "This ticket was set to **{priority}** priority but was not updated [within the SLO period]({url}). Please consider picking up this ticket or just set the ticket to the next lower priority."
-reminder_regex = r"^This ticket was set to .* priority but was not updated.* Please consider"
+reminder_regex = (
+    r"^This ticket was set to .* priority but was not updated.* Please consider"
+)
+
 
 # Initialize a blank md file to replace the current README
 def initialize_md(data):
@@ -36,7 +39,9 @@ def initialize_md(data):
 
 
 def retry_request(method, url, data, headers, attempts=7):
-    retries = Retry(total=attempts, backoff_factor=2, status_forcelist=[429, 500, 502, 503, 504])
+    retries = Retry(
+        total=attempts, backoff_factor=2, status_forcelist=[429, 500, 502, 503, 504]
+    )
     http = requests.Session()
     parsed_url = urlparse(url)
     http.mount("{}://".format(parsed_url.scheme), HTTPAdapter(max_retries=retries))
@@ -61,9 +66,7 @@ def json_rest(method, url, rest=None):
 
 def issue_reminder(conf, poo):
     priority = poo["priority"]["name"]
-    msg = reminder_text.format(
-        priority=priority, url=data["url"]
-    )
+    msg = reminder_text.format(priority=priority, url=data["url"])
     if "comment" in conf:
         msg = conf["comment"]
     if data["reminder-comment-on-issues"]:
@@ -87,12 +90,12 @@ def list_issues(conf, root):
 def reminder_exists(conf, poo, msg):
     url = "{}/{}.json".format(data["web"], poo["id"])
     root = json_rest("GET", url)
-    if root is not None and 'journals' in root['issue']:
-        journals = root['issue']['journals']
+    if root is not None and "journals" in root["issue"]:
+        journals = root["issue"]["journals"]
         for journal in journals:
-            if not 'notes' in journal or len(journal['notes']) == 0:
+            if not "notes" in journal or len(journal["notes"]) == 0:
                 continue
-            if re.search(reminder_regex, journal['notes']):
+            if re.search(reminder_regex, journal["notes"]):
                 return True
     return False
 
@@ -107,7 +110,9 @@ def check_backlog(conf):
     issue_count = list_issues(conf, root)
     good = True
     if "max" in conf:
-        good = not(issue_count > conf["max"] or "min" in conf and issue_count < conf["min"])
+        good = not (
+            issue_count > conf["max"] or "min" in conf and issue_count < conf["min"]
+        )
     return (good, issue_count)
 
 
@@ -119,11 +124,14 @@ def render_table(data):
         limits = "<" + str(conf["max"] + 1) if "max" in conf else ""
         if "min" in conf:
             limits += ", >" + str(conf["min"] - 1)
-        rows.append([
-            "[" + conf["title"] + "](" + url + ")",
-            str(issue_count),
-            limits,
-            result_icons["pass"] if good else result_icons["fail"]])
+        rows.append(
+            [
+                "[" + conf["title"] + "](" + url + ")",
+                str(issue_count),
+                limits,
+                result_icons["pass"] if good else result_icons["fail"],
+            ]
+        )
     return rows
 
 
@@ -137,7 +145,9 @@ def cycle_time(issue, status_ids):
         for detail in journal["details"]:
             if detail["name"] == "status_id":
                 if detail["new_value"] == str(status_ids["In Progress"]):
-                    start = datetime.strptime(journal["created_on"], "%Y-%m-%dT%H:%M:%SZ")
+                    start = datetime.strptime(
+                        journal["created_on"], "%Y-%m-%dT%H:%M:%SZ"
+                    )
                 elif detail["old_value"] == str(status_ids["In Progress"]):
                     end = datetime.strptime(journal["created_on"], "%Y-%m-%dT%H:%M:%SZ")
                     cycle_time += (end - start).total_seconds()
@@ -147,7 +157,7 @@ def cycle_time(issue, status_ids):
 def _today_nanoseconds():
     dt = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
     epoch = datetime.utcfromtimestamp(0)
-    return int((dt-epoch).total_seconds()*1000000000)
+    return int((dt - epoch).total_seconds() * 1000000000)
 
 
 def render_influxdb(data):
@@ -202,17 +212,20 @@ def render_influxdb(data):
                 output[-1] += " " + str(_today_nanoseconds())
     return output
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('config', default='queries.yaml', nargs='?')
-    parser.add_argument('--output', choices=['markdown', 'influxdb'], default='markdown')
-    parser.add_argument("--reminder-comment-on-issues", action='store_false')
+    parser.add_argument("config", default="queries.yaml", nargs="?")
+    parser.add_argument(
+        "--output", choices=["markdown", "influxdb"], default="markdown"
+    )
+    parser.add_argument("--reminder-comment-on-issues", action="store_false")
     switches = parser.parse_args()
     try:
         with open(switches.config, "r") as config:
             data = yaml.safe_load(config)
-            data['reminder-comment-on-issues'] = switches.reminder_comment_on_issues
-            if switches.output == 'influxdb':
+            data["reminder-comment-on-issues"] = switches.reminder_comment_on_issues
+            if switches.output == "influxdb":
                 print("\n".join(line for line in render_influxdb(data)))
             else:
                 initialize_md(data)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -122,7 +122,7 @@ class TestOutput(unittest.TestCase):
                 ]
             )
             self.assertEqual(
-                backlogger.render_table(backlogger.data),
+                backlogger.render_table(backlogger.data)[1],
                 [
                     [
                         "[Workable Backlog](https://example.com/issues?query_id=123)",

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -124,9 +124,11 @@ class TestOutput(unittest.TestCase):
             self.assertEqual(
                 backlogger.render_table(backlogger.data),
                 [
-                    ['[Workable Backlog](https://example.com/issues?query_id=123)',
-                    '2',
-                    scenario["limit"],
-                    scenario["icon"]],
+                    [
+                        "[Workable Backlog](https://example.com/issues?query_id=123)",
+                        "2",
+                        scenario["limit"],
+                        scenario["icon"],
+                    ],
                 ],
             )


### PR DESCRIPTION
Only return exit code 0 if all queries are good, return exit code 3 if
any query is not OK.

Reference: https://progress.opensuse.org/issues/137828