### PR TITLE
Include "Feedback" in cycle time as well

### DIFF
--- a/backlogger.py
+++ b/backlogger.py
@@ -145,17 +145,17 @@ def remove_project_part_from_url(url):
 def cycle_time(issue, status_ids):
     start = datetime.strptime(issue["created_on"], "%Y-%m-%dT%H:%M:%SZ")
     cycle_time = 0
-
+    in_cycle_status = [str(status_ids["In Progress"]), str(status_ids["Feedback"])]
     url = "{}/{}.json?include=journals".format(remove_project_part_from_url(data["web"]), issue["id"])
     issue = json_rest("GET", url)["issue"]
     for journal in issue["journals"]:
         for detail in journal["details"]:
             if detail["name"] == "status_id":
-                if detail["new_value"] == str(status_ids["In Progress"]):
+                if detail["new_value"] in in_cycle_status:
                     start = datetime.strptime(
                         journal["created_on"], "%Y-%m-%dT%H:%M:%SZ"
                     )
-                elif detail["old_value"] == str(status_ids["In Progress"]):
+                elif detail["old_value"] in in_cycle_status:
                     end = datetime.strptime(journal["created_on"], "%Y-%m-%dT%H:%M:%SZ")
                     cycle_time += (end - start).total_seconds()
     return cycle_time

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -21,7 +21,10 @@ class TestOutput(unittest.TestCase):
     def test_influxdb(self):
         backlogger.json_rest = MagicMock(
             side_effect=[
-                {"issue_statuses": [{"name": "In Progress", "id": 2}]},
+                {"issue_statuses": [
+                    {"name": "In Progress", "id": 2},
+                    {"name": "Feedback", "id": 4}
+                ]},
                 {
                     "issues": [
                         {
@@ -38,18 +41,24 @@ class TestOutput(unittest.TestCase):
                         },
                         {
                             "id": 3,
+                            "status": {"name": "Feedback"},
+                            "created_on": "2022-12-06T00:00:00Z",
+                            "updated_on": "2022-12-14T00:00:00Z",
+                        },
+                        {
+                            "id": 4,
                             "status": {"name": "Resolved"},
                             "created_on": "2022-12-06T13:57:05Z",
                             "updated_on": "2022-12-22T13:12:22Z",
                         },
                         {
-                            "id": 4,
+                            "id": 5,
                             "status": {"name": "Resolved"},
                             "created_on": "2022-12-08T10:00:00Z",
                             "updated_on": "2022-12-15T10:00:00Z",
                         },
                     ],
-                    "total_count": 4,
+                    "total_count": 5,
                 },
                 {
                     "issue": {
@@ -98,6 +107,7 @@ class TestOutput(unittest.TestCase):
             backlogger.render_influxdb(backlogger.data),
             [
                 'slo,team="Awesome\\ Team",status="In\\ Progress",title="Workable\\ Backlog" count=2',
+                'slo,team="Awesome\\ Team",status="Feedback",title="Workable\\ Backlog" count=1',
                 'leadTime,team="Awesome\\ Team",status="Resolved",title="Workable\\ Backlog" count=2,leadTime=275.6273611111111,cycleTime=48.0,leadTimeSum=551.2547222222222,cycleTimeSum=96.0 23',
             ],
         )


### PR DESCRIPTION
Only counting "In Progress" yields unrealistically low cycle time
values and would not reflect overall time that a common
development ticket is being worked on within a team as often
we use "Feedback" when waiting for others within the team,
e.g. for code review.

This commit counts time in status "Feedback" same as
"In Progress" to account for that.

Related progress issue: https://progress.opensuse.org/issues/155917