### PR TITLE
Fix logic for --reminder-comment-on-issues

### DIFF
--- a/backlogger.py
+++ b/backlogger.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--output", choices=["markdown", "influxdb"], default="markdown"
     )
-    parser.add_argument("--reminder-comment-on-issues", action="store_false")
+    parser.add_argument("--reminder-comment-on-issues", action="store_true")
     parser.add_argument("--exit-code", action="store_true")
     switches = parser.parse_args()
     try:


### PR DESCRIPTION
`store_false` will actually turn the switch *off* when used, so the logic was reversed.

Apparently this is broken since b260dbbb0f58a0c2a81583aaf1ac81a6ad3ecca4

Issue: https://progress.opensuse.org/issues/157522