### PR TITLE
Provide automatic priority update based on SLO requirements

### DIFF
--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 import pytest
 import re
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -72,6 +73,7 @@ class TestComments(unittest.TestCase):
                     {
                         "id": 3,
                         "notes": "This ticket was set to **High** priority but was not updated [within the SLO period](https://example.com/issues). Please consider picking up this ticket or just set the ticket to the next lower priority.",
+                        "created_on": datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
                     },
                 ],
             },
@@ -81,6 +83,7 @@ class TestComments(unittest.TestCase):
         backlogger.issue_reminder(
             {"query": "query_id=123&c%5B%5D=updated_on"},
             {"priority": {"name": "High"}, "id": 1000},
+            {'has_repeat_reminder': datetime.min, 'last_reminder': False}
         )
         backlogger.json_rest.assert_called_once_with(
             "GET",
@@ -95,6 +98,7 @@ class TestComments(unittest.TestCase):
         backlogger.issue_reminder(
             {"query": "query_id=123&c%5B%5D=updated_on"},
             {"priority": {"name": "High"}, "id": 1000},
+            {'has_repeat_reminder': datetime.min, 'last_reminder': False}
         )
         backlogger.json_rest.assert_called_once_with(
             "GET",
@@ -102,3 +106,67 @@ class TestComments(unittest.TestCase):
         )
         out, err = self.capsys.readouterr()
         assert re.match("API for 1000 returned None", err)
+
+
+    def test_automatic_priority_on_issue(self):
+        test_params = [
+            # slo_from, slo_to, slo_id, slo_days
+            ["Immediate", "Urgent", 7, 2],
+            ["Urgent", "High", 6, 25],
+            ["High", "Normal", 5, 35],
+            ["Normal", "Low", 4, 700]]
+        for params in test_params:
+            with self.subTest(params):
+                self._set_mock_data(params)
+                out, err = self.capsys.readouterr()
+                assert re.search("Reducing priority from {} to next lower {} for 1000".format(params[0],params[1]), out)
+
+
+    def test_issue_with_low_priority_never_change(self):
+        test_params = [
+            # slo_from, slo_id, slo_days
+            ["Low", 3, 2],
+            ["Low", 3, 1000]]
+        for params in test_params:
+            with self.subTest(params):
+                self._set_mock_data(params)
+                out, err = self.capsys.readouterr()
+                assert re.search("Skipping priority update for 1000", out)
+
+    def _set_mock_data(self, params):
+        if len(params) > 3:
+            past_days = params[3]
+            id = params[1]
+        else:
+            past_days = params[2]
+            id = params[1]
+        data = {"url": "https://example.com/issues", "web": "https://example.com/wiki",
+                "api": "https://example.com/issues.json",
+                "reminder-comment-on-issues": True}
+        backlogger.data = data
+        rest = {
+            "issue": {
+                "id": 1000,
+                "priority": { "id": id, "name": params[0] },
+                "journals": [
+                    { "id": 1, "notes": "" },
+                    { "id": 2, "notes": None },
+                    {
+                        "id": 3,
+                        "notes": "This ticket was set to **Urgent** priority but was not updated [within the SLO period](https://example.com/issues). Please consider picking up this ticket or just set the ticket to the next lower priority.",
+                        "created_on": (datetime.now() - timedelta(days=past_days)).strftime('%Y-%m-%dT%H:%M:%SZ')
+                    },
+                ],
+            },
+        }
+
+        backlogger.json_rest = MagicMock(return_value=rest)
+        backlogger.issue_reminder(
+            {"query": "query_id=123&c%5B%5D=updated_on"},
+            {"priority": {"name": params[0]}, "id": 1000},
+            {'has_repeat_reminder': datetime.min, 'last_reminder': False}
+        )
+        backlogger.json_rest.assert_any_call(
+            "GET",
+            "https://example.com/wiki/1000.json?include=journals",
+        )


### PR DESCRIPTION
This PR adds automatic priority updates once the issues have already a reminder. Not action is taken for Low priority. Code is moved around to avoid redundant API requests. Test code could be also improved but i thought that it wont be a big problem for now.

https://progress.opensuse.org/issues/119176