### PR TITLE
Don't show a link preview

### DIFF
--- a/head.html
+++ b/head.html
@@ -5,7 +5,6 @@
 <!-- Facebook / Slack tags -->
 <meta property="og:title" content="WORKFLOW_NAME" />
 <meta property="og:url" content="https://github.com/GITHUB_REPOSITORY" />
-<meta property="og:image" content="PREVIEW_IMAGE_URL" />
 <meta http-equiv="refresh" content="600">
 <style>
 main {


### PR DESCRIPTION
The Slack message already lists all queries exceeding limits
and the preview takes a lot of screen space and is distracting.