### PR TITLE
fix: implement build-and-deploy pattern for PR previews

### DIFF
--- a/.github/workflows/preview-deploy.yaml
+++ b/.github/workflows/preview-deploy.yaml
@@ -1,0 +1,50 @@
+---
+name: Backlog Limits Checker Deploy
+concurrency: preview-deploy-${{ github.ref }}
+# yamllint disable-line rule:truthy
+on:
+  workflow_run:
+    workflows: ["Backlog Limits Checker Build"]
+    types:
+      - completed
+jobs:
+  backlogger_preview_deploy:
+    runs-on: ubuntu-latest
+    # yamllint disable-line rule:line-length
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download PR info
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: pr-info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: pr-info
+
+      - name: Read PR info
+        id: pr-info
+        run: |
+          echo "number=$(cat pr-info/pr-number)" >> "$GITHUB_OUTPUT"
+          echo "action=$(cat pr-info/pr-action)" >> "$GITHUB_OUTPUT"
+
+      - name: Download preview artifact
+        if: steps.pr-info.outputs.action != 'closed'
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: preview-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: gh-pages
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Deploy Preview
+        # yamllint disable-line rule:line-length
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
+        with:
+          source-dir: gh-pages
+          # yamllint disable-line rule:line-length
+          action: ${{ steps.pr-info.outputs.action == 'closed' && 'remove' || 'deploy' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-deploy.yaml
+++ b/.github/workflows/preview-deploy.yaml
@@ -14,7 +14,8 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR info
-        uses: actions/download-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
           name: pr-info
@@ -29,7 +30,8 @@ jobs:
 
       - name: Download preview artifact
         if: steps.pr-info.outputs.action != 'closed'
-        uses: actions/download-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
           name: preview-artifact

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -31,14 +31,16 @@ jobs:
           echo "${{ github.event.action }}" > pr-info/pr-action
 
       - name: Upload PR info
-        uses: actions/upload-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: pr-info
           path: pr-info/
 
       - name: Upload preview artifact
         if: github.event.action != 'closed'
-        uses: actions/upload-artifact@v4
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: preview-artifact
           path: gh-pages/

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,9 +1,9 @@
 ---
-name: Backlog Limits Checker
+name: Backlog Limits Checker Build
 concurrency: preview-${{ github.ref }}
 # yamllint disable-line rule:truthy
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -12,16 +12,33 @@ on:
     branches:
       - "**"
 jobs:
-  backlogger_preview:
+  backlogger_preview_build:
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          allow-unsafe-pr-checkout: true
+
       - name: Run the action implemented in this repo
+        if: github.event.action != 'closed'
         uses: ./
         with:
           config: queries.yaml
-      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
+
+      - name: Save PR info
+        run: |
+          mkdir -p pr-info
+          echo "${{ github.event.number }}" > pr-info/pr-number
+          echo "${{ github.event.action }}" > pr-info/pr-action
+
+      - name: Upload PR info
+        uses: actions/upload-artifact@v4
         with:
-          source-dir: gh-pages
+          name: pr-info
+          path: pr-info/
+
+      - name: Upload preview artifact
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-artifact
+          path: gh-pages/

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          allow-unsafe-pr-checkout: true
       - name: Run the action implemented in this repo
         uses: ./
         with:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+---
+merge_queue:
+  status_comments: none
+  queue_controls_comment: false
+pull_request_rules:
+  - name: automatic merge for dependabot updates
+    conditions:
+      - base=main
+      - author=dependabot[bot]
+      - -label~=^acceptance-tests-needed|not-ready
+      - "#check-failure=0"
+      - "#check-pending=0"
+      - linear-history
+    actions:
+      merge:
+        method: squash

--- a/action.yaml
+++ b/action.yaml
@@ -33,12 +33,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         repository: openSUSE/backlogger
         path: backlogger
         ref: ${{ github.event.pull_request.head.sha }}
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: 3.12
     - name: Install Python dependencies
@@ -49,7 +49,7 @@ runs:
     - run: sudo apt-get update && sudo apt-get install -y kramdown weasyprint imagemagick ghostscript
       shell: bash
     - name: Get previous published state
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         ref: ${{ inputs.folder }}
         path: ${{ inputs.state }}


### PR DESCRIPTION
Motivation:
Using pull_request_target with a checkout of the PR's head code is
highly unsafe ("pwn request" vulnerability), which causes newer
versions of actions/checkout to fail by default.

Design Choices:
Implemented the standard "Build and Deploy" two-workflow pattern:
1. "Backlog Limits Checker Build" (preview.yaml) runs on pull_request.
   It executes the PR code securely in an untrusted context with a
   read-only token, generates the preview, and uploads it as an
   artifact along with PR metadata.
2. "Backlog Limits Checker Deploy" (preview-deploy.yaml) runs on
   workflow_run. It operates securely in the base repository context
   with a write token, downloads the safe HTML artifacts, and uses
   pr-preview-action to deploy to gh-pages or clean up on close.

Benefits:
This secures the workflow against malicious PRs and restores the
ability to deploy PR previews for pull requests originating from forks.

Verification:
See the demonstration PR
https://github.com/okurz/backlogger/pull/5
with a live working preview

*Note that this PR's CI checks are expected to fail due to newly enforced github security related settings and only after merge the CI checks would be able to pass*

Related issue: https://github.com/openSUSE/backlogger/pull/62