### PR TITLE
docs: update PR previews setup in README for build-and-deploy pattern

### DIFF
--- a/.github/workflows/preview-deploy.yaml
+++ b/.github/workflows/preview-deploy.yaml
@@ -13,6 +13,9 @@ jobs:
     # yamllint disable-line rule:line-length
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
       - name: Download PR info
         # yamllint disable-line rule:line-length
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -38,9 +41,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: gh-pages
 
-      # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
       - name: Deploy Preview
         # yamllint disable-line rule:line-length
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
@@ -48,5 +48,6 @@ jobs:
           source-dir: gh-pages
           # yamllint disable-line rule:line-length
           action: ${{ steps.pr-info.outputs.action == 'closed' && 'remove' || 'deploy' }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-deploy.yaml
+++ b/.github/workflows/preview-deploy.yaml
@@ -42,6 +42,7 @@ jobs:
           path: gh-pages
 
       - name: Deploy Preview
+        id: preview-step
         # yamllint disable-line rule:line-length
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9  # v1
         with:
@@ -49,5 +50,36 @@ jobs:
           # yamllint disable-line rule:line-length
           action: ${{ steps.pr-info.outputs.action == 'closed' && 'remove' || 'deploy' }}
           pr-number: ${{ steps.pr-info.outputs.number }}
+          comment: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR (deploy)
+        if: steps.pr-info.outputs.action != 'closed'
+        # yamllint disable-line rule:line-length
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db  # v2
+        with:
+          header: pr-preview
+          number: ${{ steps.pr-info.outputs.number }}
+          # yamllint disable rule:line-length
+          message: |
+            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview-step.outputs.action-version }}
+            :---:
+            | <p><img src="https://qr.rossjrw.com/?url=${{ steps.preview-step.outputs.preview-url }}" height="100" align="right" alt="QR code for preview link"></p> :rocket: View preview at <br> ${{ steps.preview-step.outputs.preview-url }} <br><br>
+            | <h6>Built to branch [`gh-pages`](https://github.com/okurz/backlogger/tree/gh-pages) at ${{ steps.preview-step.outputs.action-start-time }}. <br> Preview will be ready when the [GitHub Pages deployment](https://github.com/okurz/backlogger/deployments) is complete. <br><br> </h6>
+          # yamllint enable rule:line-length
+
+      - name: Comment on PR (remove)
+        if: steps.pr-info.outputs.action == 'closed'
+        # yamllint disable-line rule:line-length
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db  # v2
+        with:
+          header: pr-preview
+          number: ${{ steps.pr-info.outputs.number }}
+          # yamllint disable rule:line-length
+          message: |
+            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) ${{ steps.preview-step.outputs.action-version }}
+            :---:
+            Preview removed because the pull request was closed.
+            ${{ steps.preview-step.outputs.action-start-time }}
+          # yamllint enable rule:line-length

--- a/README.md
+++ b/README.md
@@ -51,36 +51,101 @@ jobs:
 
 ## Previews for pull requests
 
+To securely generate and deploy previews for pull requests (including those from forks), use a secure two-workflow "Build and Deploy" pattern.
+
+### 1. Build Workflow
+
+Create `.github/workflows/preview-build.yml` triggered on the `pull_request` event:
+
 ```yaml
+name: Preview Build
 concurrency: preview-${{ github.ref }}
 on:
-  pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
-    branches:
-      - "**"
-permissions:
-  contents: write
-  pull-requests: write
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
 jobs:
-  backlogger:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: openSUSE/backlogger@main
+      - uses: actions/checkout@v4
+      - name: Run backlogger
+        if: github.event.action != 'closed'
+        uses: openSUSE/backlogger@main
         with:
           redmine_api_key: ${{ secrets.REDMINE_API_KEY }}
-      - uses: rossjrw/pr-preview-action@v1
+      - name: Save PR info
+        run: |
+          mkdir -p pr-info
+          echo "${{ github.event.number }}" > pr-info/pr-number
+          echo "${{ github.event.action }}" > pr-info/pr-action
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-info
+          path: pr-info/
+      - name: Upload preview artifact
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-artifact
+          path: gh-pages/
 ```
 
-> [!NOTE]
-> [rossjrw/pr-preview-action](https://github.com/rossjrw/pr-preview-action)
-> doesn't support forked repositories.
-> Note the use of `pull_request_target` and `branches` as a
-> work-around with the caveat that previews only show HTML changes.
+### 2. Deploy Workflow
+
+Create `.github/workflows/preview-deploy.yml` triggered on the `workflow_run` event:
+
+```yaml
+name: Preview Deploy
+on:
+  workflow_run:
+    workflows: ["Preview Build"]
+    types: [completed]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download PR info
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: pr-info
+          path: pr-info
+      - id: pr-info
+        run: |
+          echo "number=$(cat pr-info/pr-number)" >> "$GITHUB_OUTPUT"
+          echo "action=$(cat pr-info/pr-action)" >> "$GITHUB_OUTPUT"
+      - name: Download preview
+        if: steps.pr-info.outputs.action != 'closed'
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: preview-artifact
+          path: gh-pages
+      - uses: rossjrw/pr-preview-action@v1
+        id: preview-step
+        with:
+          source-dir: gh-pages
+          action: ${{ steps.pr-info.outputs.action == 'closed' && 'remove' || 'deploy' }}
+          pr-number: ${{ steps.pr-info.outputs.number }}
+          comment: false
+      - name: Comment on PR (deploy)
+        if: steps.pr-info.outputs.action != 'closed'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          number: ${{ steps.pr-info.outputs.number }}
+          message: |
+            View preview at: ${{ steps.preview-step.outputs.preview-url }}
+      - name: Comment on PR (remove)
+        if: steps.pr-info.outputs.action == 'closed'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          number: ${{ steps.pr-info.outputs.number }}
+          message: Preview removed because the pull request was closed.
+```
 
 ## License
 


### PR DESCRIPTION
Motivation
The old README instructions recommended pull_request_target which is
unsafe when checking out and running untrusted PR code, leading to
security vulnerabilities and action checkout failures.

Design Choices
Updated the "Previews for pull requests" section to describe the new,
secure two-workflow Build and Deploy setup with clear instructions and
example workflow files.

Benefits
Ensures anyone setting up backlogger previews in the future starts with
a completely secure workflow structure that works out-of-the-box for
fork PRs.